### PR TITLE
Fix chat interface MIME types and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,39 @@ The frontend dashboard provides:
 - **Message Details Modal**: View complete message information
 - **Responsive Design**: Works on desktop and mobile devices
 
+## 💬 Chat Interface (Port 3001)
+
+- **Access**: `http://localhost:3001`
+- **Purpose**: Simple chat UI for end-users to talk to the RAG assistant
+- **Files**: `chat_interface/index.html`, `chat_interface/chat.css`, `chat_interface/chat.js`, `chat_interface/nginx.conf`
+
+### How it connects to the backend
+- When opened on `localhost`, the UI calls the backend directly at `http://localhost:8000`
+- In non-local deployments, the chat interface calls its own host (`/health`, `/chat`, etc.) and Nginx proxies those paths to the backend
+- Nginx routes are defined as exact path matches to avoid collisions with static assets
+
+### Features
+- Send messages and receive LLM responses
+- Quick actions for common queries
+- Local conversation history sidebar
+- Export conversation as JSON
+- Open dashboard shortcut
+
+### Customize the UI
+- Edit `chat_interface/chat.css` for styling
+- Edit `chat_interface/chat.js` for behavior and API paths
+- Rebuild and restart the chat interface service:
+
+```bash
+docker-compose build chat_interface && docker-compose up -d chat_interface
+```
+
+### Troubleshooting
+- If `chat.css` or `chat.js` fail to load with a MIME type error and `X-Content-Type-Options: nosniff`:
+  - Ensure Nginx uses exact path locations for API routes (`location = /chat`, `location = /health`, etc.) so that `/chat.css` and `/chat.js` are served as static files instead of being proxied
+  - Rebuild/restart the `chat_interface` service after changes
+- Verify backend health at `http://localhost:8000/health`
+
 ## 🗄️ Database Schema
 
 ### `message_logs` Table

--- a/chat_interface/nginx.conf
+++ b/chat_interface/nginx.conf
@@ -42,7 +42,7 @@ http {
         }
 
         # Proxy API calls to backend
-        location /health {
+        location = /health {
             proxy_pass http://backend:8000/health;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -50,7 +50,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
         
-        location /chat {
+        location = /chat {
             proxy_pass http://backend:8000/chat;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -59,7 +59,7 @@ http {
             proxy_buffering off;
         }
         
-        location /query_generate {
+        location = /query_generate {
             proxy_pass http://backend:8000/query_generate;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -68,7 +68,7 @@ http {
             proxy_buffering off;
         }
         
-        location /answer_generate {
+        location = /answer_generate {
             proxy_pass http://backend:8000/answer_generate;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Fix MIME type errors for chat interface static assets and add chat interface documentation to README.

Nginx's `location /chat` was incorrectly proxying `/chat.css` and `/chat.js` to the backend, causing MIME type mismatches. This is resolved by using exact path matches for API locations in `nginx.conf`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd1bf7c6-b832-4d7f-9fb2-2f57a434626a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd1bf7c6-b832-4d7f-9fb2-2f57a434626a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

